### PR TITLE
Fixes "is_assoc bug"

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -810,7 +810,7 @@ Class krumo {
 		// boolean
 		if (is_bool($data)) {
 			return krumo::_boolean($data, $name);
-		}a
+		}
 
 		// null
 		if (is_null($data)) {


### PR DESCRIPTION
Fixes the bug which prevent calling to `is_assoc` method by declaring this method as static.

-- error without the fix:
`Runtime Notice: Non-static method krumo::is_assoc() should not be called statically in /home/some-user/***/vendor/oodle/krumo/class.krumo.php line 1047"`
