### PR TITLE
Fixed recursion error

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1047,6 +1047,7 @@ class Krumo
         // recursion detected
         if ($_r > 0) {
             static::_recursion();
+            return;
         }
 
         // stain it


### PR DESCRIPTION
In older versions of krumo, this method returned a string instead of outputting it. At that time, static::_recursion() was returned. "return krumo::_recursion();"

An error occured in my project when I updated to the last version, and I traced the error to this line. Please look at this pull request and accept it if I am right.