### PR TITLE
#48 introducing krumo::queue()

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -615,7 +615,7 @@ class Krumo
           func_get_args()
           );
 
-        register_shutdown_function('print', $output);
+        register_shutdown_function('printf', '%s', $output);
         return $output;
     }
 

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -575,7 +575,7 @@ class Krumo
 
     /**
     * Return the dump information about a variable
-    * @param mixed $data,...
+    * @param mixed ...$data
     * @return string
     */
     static function fetch($data)
@@ -594,6 +594,29 @@ class Krumo
             );
 
         return ob_get_clean();
+    }
+
+    /**
+    * Prints the dump information about variable\variables at end of a script
+    * @param mixed ...$data pass as many arguments as you want
+    * @return string
+    */
+    static function queue($data)
+    {
+        // disabled ?
+        //
+        if (!self::_debug())
+        {
+            return false;
+        }
+
+        $output = call_user_func_array(
+          array(get_called_class(), 'fetch'),
+          func_get_args()
+          );
+
+        register_shutdown_function('print', $output);
+        return $output;
     }
 
     /**


### PR DESCRIPTION
This is the feature discussed in #48. What this does is to capture the output immediatelly using `krumo::fetch()`, and then schedule it to be printed at the end of the execution of the script using `register_shutdown_function()`.

What it does can be demonstrated with the following script:
```php
<?php 
require 'class.krumo.php';
var_dump(123);
krumo::queue(456);
var_dump(789);
```
The output is
```
/Users/kt/mmucklo-krumo/a.php:3:
int(123)
/Users/kt/mmucklo-krumo/a.php:5:
int(789)
--------------------------------------------------------------------------------
456

Called from /Users/kt/mmucklo-krumo/a.php, line 4  (Krumo version 0.6.1)
--------------------------------------------------------------------------------
```
Same will happen when using it on a web page, where the output HTML is printed at the end of the script's life and will appear at the bottom of the page.