### PR TITLE
Allow truncation of huge arrays

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1096,7 +1096,7 @@ class Krumo
                 if ($k === $_recursion_marker) {
                     continue;
                 }
-                
+
                 // skip items beyond the limit, if any
                 if ( $i >= $limit && $limit > 0 ) {
                     $truncated++;
@@ -1109,15 +1109,11 @@ class Krumo
             }
 
             if ( $truncated > 0 ) {
-                print "<li class=\"krumo-child\">";
+                print "\n<li class=\"krumo-child\">";
                 print "<div class=\"krumo-element \" ";
-                print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
-                print "<a class=\"krumo-name\">truncated</a> ";
-                print "<div class=\"krumo-nest\">";
-                print "<ul class=\"krumo-node\">";
-                print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $truncated . " items not shown</div></li>";
-                print "</ul></div>";
-                print "</div></li>";
+                print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">";
+                print "<a class=\"krumo-name\">Array output truncated ($truncated items not shown)</a>";
+                print "</div></li>\n";
             }
         }
 

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1098,10 +1098,9 @@ class Krumo
                     continue;
                 }
 
-                // get real value
-                $v =& $data[$k];
-
                 if ( 0 <= $limit ) {
+                    // get real value
+                    $v =& $data[$k];
                     static::_dump($v, $k);
                     $limit--;
                 }

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1097,14 +1097,15 @@ class Krumo
                     continue;
                 }
                 
+                // skip items beyond the limit, if any
                 if ( $i >= $limit && $limit > 0 ) {
-	                $truncated++;
-	                continue;
+                    $truncated++;
+                    continue;
                 }
-	
-	            // get real value
-	            $v =& $data[$k];
-	            static::_dump($v, $k);
+
+                // get real value and dump
+                $v =& $data[$k];
+                static::_dump($v, $k);
             }
 
             if ( $truncated > 0 ) {

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1087,23 +1087,24 @@ class Krumo
             // keys
             $keys = array_keys($data);
 
-            $limit = (int) static::_config('display', 'truncate_count', -1);
-            $truncated = count($data) - $limit;
+            $limit = (int) static::_config('display', 'truncate_count', 0);
+            $truncated = 0;
 
             // iterate
-            foreach ($keys as $k) {
+            foreach ($keys as $i => $k) {
                 // skip marker
                 if ($k === $_recursion_marker) {
-                    $truncated--;
                     continue;
                 }
-
-                if ( 0 <= $limit ) {
-                    // get real value
-                    $v =& $data[$k];
-                    static::_dump($v, $k);
-                    $limit--;
+                
+                if ( $i >= $limit && $limit > 0 ) {
+	                $truncated++;
+	                continue;
                 }
+	
+	            // get real value
+	            $v =& $data[$k];
+	            static::_dump($v, $k);
             }
 
             if ( $truncated > 0 ) {

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1087,6 +1087,8 @@ class Krumo
             // keys
             $keys = array_keys($data);
 
+	        $limit = (int) static::_config('display', 'truncate_count', -1);
+
             // iterate
             foreach ($keys as $k) {
                 // skip marker
@@ -1098,6 +1100,26 @@ class Krumo
                 $v =& $data[$k];
 
                 static::_dump($v, $k);
+	
+	            $limit--;
+	            if ( 0 === $limit ) {
+		            $count = count($data);
+	            	$remaining = $count - $limit . ' items not shown';
+					
+	            	if ( $remaining > 0 ) {
+			            print "<li class=\"krumo-child\">";
+			            print "<div class=\"krumo-element \" ";
+			            print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
+			            print "<a class=\"krumo-name\">truncated</a> ";
+			            print "<div class=\"krumo-nest\">";
+			            print "<ul class=\"krumo-node\">";
+			            print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $remaining . "</div></li>";
+			            print "</ul></div>";
+			            print "</div></li>";
+			            
+			            break;
+		            }
+	            }
             }
         }
 

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1094,29 +1094,29 @@ class Krumo
             foreach ($keys as $k) {
                 // skip marker
                 if ($k === $_recursion_marker) {
+                    $truncated--;
                     continue;
                 }
 
                 // get real value
                 $v =& $data[$k];
 
-                static::_dump($v, $k);
-
-                $limit--;
-                if ( 0 === $limit ) {
-                    if ( $truncated > 0 ) {
-                        print "<li class=\"krumo-child\">";
-                        print "<div class=\"krumo-element \" ";
-                        print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
-                        print "<a class=\"krumo-name\">truncated</a> ";
-                        print "<div class=\"krumo-nest\">";
-                        print "<ul class=\"krumo-node\">";
-                        print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $truncated . " items not shown</div></li>";
-                        print "</ul></div>";
-                        print "</div></li>";
-                    }
-                    break;
+                if ( 0 <= $limit ) {
+                    static::_dump($v, $k);
+                    $limit--;
                 }
+            }
+
+            if ( $truncated > 0 ) {
+                print "<li class=\"krumo-child\">";
+                print "<div class=\"krumo-element \" ";
+                print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
+                print "<a class=\"krumo-name\">truncated</a> ";
+                print "<div class=\"krumo-nest\">";
+                print "<ul class=\"krumo-node\">";
+                print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $truncated . " items not shown</div></li>";
+                print "</ul></div>";
+                print "</div></li>";
             }
         }
 

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1087,7 +1087,9 @@ class Krumo
             // keys
             $keys = array_keys($data);
 
-	        $limit = (int) static::_config('display', 'truncate_count', -1);
+            $limit = (int) static::_config('display', 'truncate_count', -1);
+            $count = count($data);
+            $truncated = $count - $limit;
 
             // iterate
             foreach ($keys as $k) {
@@ -1100,26 +1102,23 @@ class Krumo
                 $v =& $data[$k];
 
                 static::_dump($v, $k);
-	
-	            $limit--;
-	            if ( 0 === $limit ) {
-		            $count = count($data);
-	            	$remaining = $count - $limit . ' items not shown';
-					
-	            	if ( $remaining > 0 ) {
-			            print "<li class=\"krumo-child\">";
-			            print "<div class=\"krumo-element \" ";
-			            print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
-			            print "<a class=\"krumo-name\">truncated</a> ";
-			            print "<div class=\"krumo-nest\">";
-			            print "<ul class=\"krumo-node\">";
-			            print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $remaining . "</div></li>";
-			            print "</ul></div>";
-			            print "</div></li>";
-			            
-			            break;
-		            }
-	            }
+
+                $limit--;
+                if ( 0 === $limit ) {
+                    if ( $truncated > 0 ) {
+                        print "<li class=\"krumo-child\">";
+                        print "<div class=\"krumo-element \" ";
+                        print "onMouseOver=\"krumo.over(this);\" onMouseOut=\"krumo.out(this);\">\n";
+                        print "<a class=\"krumo-name\">truncated</a> ";
+                        print "<div class=\"krumo-nest\">";
+                        print "<ul class=\"krumo-node\">";
+                        print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $truncated . " items not shown</div></li>";
+                        print "</ul></div>";
+                        print "</div></li>";
+                        
+                        break;
+                    }
+                }
             }
         }
 

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1088,8 +1088,7 @@ class Krumo
             $keys = array_keys($data);
 
             $limit = (int) static::_config('display', 'truncate_count', -1);
-            $count = count($data);
-            $truncated = $count - $limit;
+            $truncated = count($data) - $limit;
 
             // iterate
             foreach ($keys as $k) {
@@ -1115,9 +1114,8 @@ class Krumo
                         print "<li class=\"krumo-child\"> <div class=\"krumo-preview\">" . $truncated . " items not shown</div></li>";
                         print "</ul></div>";
                         print "</div></li>";
-                        
-                        break;
                     }
+                    break;
                 }
             }
         }

--- a/krumo.sample.ini
+++ b/krumo.sample.ini
@@ -27,6 +27,9 @@
 ; Truncated items are still shown in full in the drop down.
 ;truncate_length = 80
 
+; Truncate arrays that have more than X elements.
+;truncate_count = 120
+
 ; Uncomment the lines below to specify the node_collapse sequence
 ; This example expands the first level with less than 5 elements
 ; and the second level with less than 10 items.


### PR DESCRIPTION
I've ran into an issue, when dumping Objects that contained long arrays. They were not particularly big, as they only contained numbers (IDs), however Krumo struggled to create the HTML markup for arrays with several thousands of items. This resulted in timeouts and broken markup.

On the other hand these IDs were not really interesting, at least not beyond checking few of them, so I've decided to implement an Array truncate feature.

Thinking this situation may happen to others here's a PR:

New configuration option in `krumo.ini`: `truncate_count` - based on `truncate_length` option. If set, only the first X array items are rendered, and the rest is omitted with a note about how many are not shown.

The default is disabled, which means arrays are still dumped entirely unless configured otherwise, in other words no changes for existing users.