### PR TITLE
fix leading whitespace tooltip

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1501,7 +1501,7 @@ class Krumo
 
         // Check for and highlight any leading or trailing spaces/tabs
         if (preg_match("/^([ \t]+)|([ \t]+)$/", $data)) {
-            $has_leading  = preg_match("/^([ \t]s+)/", $data);
+            $has_leading  = preg_match("/^([ \t]+)/", $data);
             $has_trailing = preg_match("/([ \t]+)$/", $data);
 
             if ($has_leading && $has_trailing) {


### PR DESCRIPTION
modify the regex to fix the empty tooltip when there is a leading space in string