### PR TITLE
Fix an error with newer PHP versions erroring on date() calls

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1424,7 +1424,7 @@ class Krumo
     private static function is_datetime($name, $value)
     {
         // If the name contains date or time, and the value looks like a unixtime
-        if (preg_match("/date|time/i", $name) && ($value > 10000000 && $value < 4000000000)) {
+        if (preg_match("/date|time/i", $name) && (is_numeric($value) && $value > 10000000 && $value < 4000000000)) {
             $ret = date("r", $value);
 
             return $ret;


### PR DESCRIPTION
This solves: `Uncaught TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given in ...`

You can recreate this error with the following code:

```
$x = [ 'query_time' => '123456789 ms', 'query_time2' => 123456789 ];
k($x);
```