### PR TITLE
Fix deprecated message appearing in web context with PHP 8.1

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -499,8 +499,9 @@ class Krumo
         $_ = debug_backtrace();
         while ($d = array_pop($_)) {
             $callback = static::$lineNumberTestCallback;
-            $function = strToLower($d['function']);
-            if (in_array($function, array("krumo","k","kd")) || (isset($d['class']) && strToLower($d['class']) == 'krumo') || (is_callable($callback) && call_user_func($callback, $d))) {
+            $class    = strtolower($d['class'] ?? '');
+            $function = strtolower($d['function'] ?? '');
+            if (in_array($function, array('krumo','k','kd')) || $class == 'krumo' || (is_callable($callback) && call_user_func($callback, $d))) {
                 break;
             }
         }

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -500,7 +500,7 @@ class Krumo
         while ($d = array_pop($_)) {
             $callback = static::$lineNumberTestCallback;
             $function = strToLower($d['function']);
-            if (in_array($function, array("krumo","k","kd")) || (strToLower(@$d['class']) == 'krumo') || (is_callable($callback) && call_user_func($callback, $d))) {
+            if (in_array($function, array("krumo","k","kd")) || (isset($d['class']) && strToLower($d['class']) == 'krumo') || (is_callable($callback) && call_user_func($callback, $d))) {
                 break;
             }
         }


### PR DESCRIPTION
Using krumo with PHP 8.1 and strict types always gives a deprected message:

> **Deprecated:** strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in **[...]/vendor/mmucklo/krumo/class.krumo.php** on line **503**

It appears that the `@$d['class']` is problematic here, which results in `null` if not defined:

```php
if (in_array($function, array("krumo","k","kd")) || (strToLower(@$d['class']) == 'krumo') || (is_callable($callback) && call_user_func($callback, $d))) {
    break;
}
```

This PR fixes the issue by checking the existence with `isset($d['class'])` first.

Would be happy, if @mmucklo could release a fixed version! :-)