### PR TITLE
Fix deprecation message appearing in CLI context with PHP 8.1

### DIFF
--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1607,8 +1607,8 @@ class Krumo
         }
 
         foreach ($args as $i) {
-            $out = var_export($i);
-            print trim((string) $out);
+            $out = var_export($i) ?? '';
+            print trim($out);
 
             if (sizeof($args) >= 1) {
                 $version = Krumo::VERSION;

--- a/class.krumo.php
+++ b/class.krumo.php
@@ -1608,7 +1608,7 @@ class Krumo
 
         foreach ($args as $i) {
             $out = var_export($i);
-            print trim($out);
+            print trim((string) $out);
 
             if (sizeof($args) >= 1) {
                 $version = Krumo::VERSION;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     }
     ],
     "require": {
-        "php": ">=5.2.17"
+        "php": ">=7.0"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "dev-master",


### PR DESCRIPTION
Extracted into a separate PR upon request in https://github.com/mmucklo/krumo/pull/64#issuecomment-1200501412.

This fixes another deprecation only related to CLI dumping. Please consider the following sample:

```php
<?php

declare(strict_types=1);

require_once 'vendor/autoload.php';

Krumo::dump(null);
```

The output is as follows, with PHP 8.1 there is a deprecation:

```bash
driehle@DESKTOP-DENNIS:~/tmp$ php8.0 test.php
--------------------------------------------------------------------------------
NULL

Called from /home/driehle/tmp/test.php, line 7  (Krumo version 0.6.1)
--------------------------------------------------------------------------------

driehle@DESKTOP-DENNIS:~/tmp$ php8.1 test.php
--------------------------------------------------------------------------------
NULLPHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/driehle/tmp/vendor/mmucklo/krumo/class.krumo.php on line 1611


Called from /home/driehle/tmp/test.php, line 7  (Krumo version 0.6.1)
--------------------------------------------------------------------------------
```
